### PR TITLE
[CMS-110] - the application restarts when the connection fails

### DIFF
--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -21,8 +21,13 @@ defmodule Gremlex.Client do
 
   @spec start_link({String.t(), number(), String.t()}) :: pid()
   def start_link({host, port, path}) do
-    socket = Socket.Web.connect!(host, port, path: path)
-    GenServer.start_link(__MODULE__, socket, [])
+    case Socket.Web.connect(host, port, path: path) do
+      {:ok, socket} ->
+        GenServer.start_link(__MODULE__, socket, [])
+      error ->
+        Logger.error("Error establishing connection to server: #{inspect(error)}")
+        GenServer.start_link(__MODULE__, %{}, [])
+    end
   end
 
   @spec init(Socket.Web.t()) :: state


### PR DESCRIPTION
Problem:
When the Gremlin server is not available and Gremlex wants to establish a connection or already established one, the application does not restarts properly and GemServer terminates the application.

Solution:
Thanks to @barakyo, the solution is call `GenServer.start_link` even when cannot connect and return the result so `poolboy` do not crash.