### PR TITLE
Add convenient functions for support namespaces.

### DIFF
--- a/lib/gremlex/application.ex
+++ b/lib/gremlex/application.ex
@@ -27,7 +27,6 @@ defmodule Gremlex.Application do
       |> parse_port()
     path = Confex.fetch_env!(:gremlex, :path)
     pool_size = Confex.fetch_env!(:gremlex, :pool_size)
-
     pool_options = [
       name: {:local, :gremlex},
       worker_module: Gremlex.Client,

--- a/lib/gremlex/graph.ex
+++ b/lib/gremlex/graph.ex
@@ -21,6 +21,8 @@ defmodule Gremlex.Graph do
   alias :queue, as: Queue
 
   @type t :: {[], []}
+  @default_namespace_property "namespace"
+  @default_namespace "gremlex"
 
   @doc """
   Start of graph traversal. All graph operations are stored in a queue.
@@ -251,6 +253,30 @@ defmodule Gremlex.Graph do
   end
 
   @doc """
+  Adds a namespace as property
+  """
+  @spec add_namespace(Gremlex.Graph.t()) :: Gremlex.Graph.t()
+  def add_namespace(graph) do
+    add_namespace(graph, namespace())
+  end
+
+  @spec add_namespace(Gremlex.Graph.t(), any()) :: Gremlex.Graph.t()
+  def add_namespace(graph, ns) do
+    graph |> property(namespace_property(), ns)
+  end
+
+  @spec has_namespace(Gremlex.Graph.t()) :: Gremlex.Graph.t()
+  def has_namespace(graph) do
+    has_namespace(graph, namespace())
+  end
+
+  @spec has_namespace(Gremlex.Graph.t(), any()) :: Gremlex.Graph.t()
+  def has_namespace(graph, ns) do
+    graph |> has(namespace_property(), ns)
+  end
+
+
+  @doc """
   Compiles a graph into the Gremlin query.
   """
   @spec encode(Gremlex.Graph.t()) :: String.t()
@@ -284,5 +310,13 @@ defmodule Gremlex.Graph do
       |> Enum.join(", ")
 
     encode(remainder, acc <> ".#{op}(#{args})")
+  end
+
+  defp namespace_property do
+    Confex.get_env(:gremlex, :namespace_property, @default_namespace_property)
+  end
+
+  defp namespace do
+    Confex.get_env(:gremlex, :namespace_name, @default_namespace)
   end
 end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -54,6 +54,13 @@ defmodule Gremlex.ClientTests do
       assert vertex.label == "person"
     end
 
+    test "allows you to create a relatnew vertex with a namespace" do
+      {_, [s]} = g() |> add_v("foo") |> add_namespace() |> query()
+      {_, [t]} = g() |> add_v("bar") |> add_namespace("baz") |> query()
+      assert s.properties.namespace == ["gremlex"]
+      assert t.properties.namespace == ["baz"]
+    end
+
     test "allows you to create a relationship between two vertices" do
       {_, [s]} = g() |> add_v("foo") |> property("name", "bar") |> query()
       {_, [t]} = g() |> add_v("bar") |> property("name", "baz") |> query()

--- a/test/graph_test.exs
+++ b/test/graph_test.exs
@@ -51,6 +51,38 @@ defmodule Gremlex.GraphTests do
     end
   end
 
+  describe "add_namespace/1" do
+    test "adds a property function with the default namespace value to the queue" do
+      actual_graph = g() |> Graph.add_namespace()
+      expected_graph = Queue.in({"property", ["namespace", "gremlex"]}, Queue.new())
+      assert actual_graph == expected_graph
+    end
+  end
+
+  describe "add_namespace/2" do
+    test "adds a property function namespace value to the queue" do
+      actual_graph = g() |> Graph.add_namespace("bar")
+      expected_graph = Queue.in({"property", ["namespace", "bar"]}, Queue.new())
+      assert actual_graph == expected_graph
+    end
+  end
+
+  describe "has_namespace/1" do
+    test "adds a has function to the queue with the default namespace" do
+      actual_graph = g() |> Graph.has_namespace()
+      expected_graph = Queue.in({"has", ["namespace", "gremlex"]}, Queue.new())
+      assert actual_graph == expected_graph
+    end
+  end
+
+  describe "has_namespace/2" do
+    test "has a property function to the queue with the namespace" do
+      actual_graph = g() |> Graph.has_namespace("bar")
+      expected_graph = Queue.in({"has", ["namespace", "bar"]}, Queue.new())
+      assert actual_graph == expected_graph
+    end
+  end
+
   describe "values/2" do
     test "adds a value function the queue" do
       actual_graph = g() |> values("foo")


### PR DESCRIPTION
Added Graph functions: `add_namespace/1`, `add_namespace/2`,  `has_namespace/1` and `has_namespace/2`

You can set the env variables `namespace_property` and `namespace_name` for override the default namespace property name and value.

