### PR TITLE
do not crash when starting without env vars setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 gremlex-*.tar
 
+.elixir_ls


### PR DESCRIPTION
Adds a safety check to avoid crashing the client app when there is no configuration setup for gremlex. 
Also emits a warning to let users know of this fact.