### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ An Elixir client for [Gremlin](http://tinkerpop.apache.org/gremlin.html).
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `gremlex` to your list of dependencies in `mix.exs`:
+Add the Github repo URL to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:gremlex, "~> 0.1.0"}
+    {:gremlex, git: "https://github.com/Revmaker/gremlex.git"}
   ]
 end
 ```


### PR DESCRIPTION
Gremlex is not available in Hex, so the Github URL should be used.