### PR TITLE
Call out TikerPop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Gremlex
 
-An Elixir client for [Gremlin](http://tinkerpop.apache.org/gremlin.html).
+An Elixir client for Apache TinkerPop™ aka [Gremlin](http://tinkerpop.apache.org/gremlin.html).
 
 Gremlex does not support all functions (yet). It is pretty early on in it's development. But you can always use raw Gremlin queries by using `Client.query("<Insert gremlin query>")`
 


### PR DESCRIPTION
We asked to add Gremlex to the Apache TinkerPop documentation [PR](https://github.com/apache/tinkerpop/pull/938), and they requested we add the official name.