### PR TITLE
groupCount with string

### DIFF
--- a/lib/gremlex/graph.ex
+++ b/lib/gremlex/graph.ex
@@ -346,6 +346,11 @@ defmodule Gremlex.Graph do
     enqueue(graph, "groupCount", [])
   end
 
+  @doc """
+  Appends groupCount command to the traversal. Takes in a graph and the name
+  of the key that will hold the aggregated grouping.
+  Returns a graph to allow chainig.
+  """
   @spec group_count(Gremlex.Graph.t(), String.t()) :: Gremlex.Graph.t()
   def group_count(graph, key) do
     enqueue(graph, "groupCount", key)

--- a/lib/gremlex/graph.ex
+++ b/lib/gremlex/graph.ex
@@ -346,6 +346,11 @@ defmodule Gremlex.Graph do
     enqueue(graph, "groupCount", [])
   end
 
+  @spec group_count(Gremlex.Graph.t(), String.t()) :: Gremlex.Graph.t()
+  def group_count(graph, key) do
+    enqueue(graph, "groupCount", key)
+  end
+
   defp enqueue(graph, op, args) when is_list(args) do
     Queue.in({op, args}, graph)
   end

--- a/test/graph_test.exs
+++ b/test/graph_test.exs
@@ -483,6 +483,14 @@ defmodule Gremlex.GraphTests do
     end
   end
 
+  describe "group_count/2" do
+    test "adds a groupCount function to the queue" do
+      actual_graph = g() |> group_count("foo")
+      expected_graph = Queue.in({"groupCount", ["foo"]}, Queue.new())
+      assert actual_graph == expected_graph
+    end
+  end
+
   describe "encode/1" do
     test "compiles queue into a query" do
       graph =


### PR DESCRIPTION
http://tinkerpop.apache.org/docs/current/reference/#groupcount-step

Turns out I'm blind and there _was_ and example for `groupCount(String)`