### PR TITLE
Application.build_app_worker: Update last param

### DIFF
--- a/lib/gremlex/application.ex
+++ b/lib/gremlex/application.ex
@@ -30,8 +30,7 @@ defmodule Gremlex.Application do
     end
   end
 
-  defp build_app_worker(:not_set, :not_set, :not_set, :not_set, :not_set) do
-    Logger.warn("Gremlex application will not start because of missing configuration.")
+  defp build_app_worker(:not_set, :not_set, :not_set, :not_set, _) do
     []
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gremlex.MixProject do
   def project do
     [
       app: :gremlex,
-      version: "0.2.0",
+      version: "0.3.1",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
`secure` is never set to :not_set, so this function was never actually called. The application would then crash when starting up with an invalid config. By not crashing on start, this allows us to fix the configuration and create dynamic connections with Gremlin (to be used by gremlin_export and gremlin_import).

This basically fixes this error when you don't have config values set:
```
08:44:23.559 [info]  Application gremlex exited: Gremlex.Application.start(:normal, []) returned an error: shutdown: failed to start child: :gremlex
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:EXIT, {:function_clause, [{Socket.TCP, :connect, [:not_set, :not_set, []], [file: 'lib/socket/tcp.ex', line: 104]}, {Socket.TCP, :connect!, 3, [file: 'lib/socket/tcp.ex', line: 116]}, {Socket.Web, :connect!, 3, [file: 'lib/socket/web.ex', line: 235]}, {Socket.Web, :connect, 3, [file: 'lib/socket/web.ex', line: 156]}, {Gremlex.Client, :start_link, 1, [file: 'lib/gremlex/client.ex', line: 24]}, {:supervisor, :do_start_child_i, 3, [file: 'supervisor.erl', line: 379]}, {:supervisor, :handle_call, 3, [file: 'supervisor.erl', line: 404]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}]}}}
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:275: :poolboy.new_worker/1
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:296: :poolboy.prepopulate/3
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:145: :poolboy.init/3
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
** (Mix) Could not start application gremlex: Gremlex.Application.start(:normal, []) returned an error: shutdown: failed to start child: :gremlex
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:EXIT, {:function_clause, [{Socket.TCP, :connect, [:not_set, :not_set, []], [file: 'lib/socket/tcp.ex', line: 104]}, {Socket.TCP, :connect!, 3, [file: 'lib/socket/tcp.ex', line: 116]}, {Socket.Web, :connect!, 3, [file: 'lib/socket/web.ex', line: 235]}, {Socket.Web, :connect, 3, [file: 'lib/socket/web.ex', line: 156]}, {Gremlex.Client, :start_link, 1, [file: 'lib/gremlex/client.ex', line: 24]}, {:supervisor, :do_start_child_i, 3, [file: 'supervisor.erl', line: 379]}, {:supervisor, :handle_call, 3, [file: 'supervisor.erl', line: 404]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}]}}}
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:275: :poolboy.new_worker/1
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:296: :poolboy.prepopulate/3
            (poolboy) /Users/barakyo/Development/gremlex/deps/poolboy/src/poolboy.erl:145: :poolboy.init/3
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```