### PR TITLE
Timeout Support

### DIFF
--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -59,7 +59,8 @@ defmodule Gremlex.Client do
   end
 
   # Server Methods
-  @spec handle_call({:query, String.t(), number() | :infinity}, pid(), state) :: {:reply, response, state}
+  @spec handle_call({:query, String.t(), number() | :infinity}, pid(), state) ::
+          {:reply, response, state}
   def handle_call({:query, payload, timeout}, _from, %{socket: socket} = state) do
     Socket.Web.send!(socket, {:text, payload})
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gremlex.MixProject do
   def project do
     [
       app: :gremlex,
-      version: "0.3.1",
+      version: "0.3.2",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Changes
`Client.query` now supports an optional timeout

Updated `Client.query/1` to accept an optional timeout parameter which can be passed to the GenServer and Task.await call. This helps with long queries that either take a long time to return from the server or to deserialize.

This helps with the `gremlin_export` where a query was taking a long time to deserialize (should we consider moving deserialize out of the Task.await call?).

This allows users to specify a timeout when making calls. Example:
```elixir
{:ok, nodes} = Client.query("g.V('#{node_id}').repeat(out()).until(hasLabel('Action')).path().by(tree())", 15_000)
```