### PR TITLE
Gracefully Handle Websocket Closed Connections

### DIFF
--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -14,6 +14,7 @@ defmodule Gremlex.Client do
           | {:error, :script_evaluation_error, String.t()}
           | {:error, :server_timeout, String.t()}
           | {:error, :server_serialization_error, String.t()}
+          | {:error, :websocket_closed, nil}
 
   require Logger
   alias Gremlex.Request
@@ -117,6 +118,9 @@ defmodule Gremlex.Client do
   @spec recv(Socket.Web.t(), list()) :: response
   defp recv(socket, acc \\ []) do
     case Socket.Web.recv!(socket) do
+      {:close, :abnormal, nil} ->
+        {:error, :websocket_closed, nil}
+
       {:text, data} ->
         response = Poison.decode!(data)
         result = Deserializer.deserialize(response)


### PR DESCRIPTION
Hi friends :wave: , 

I'm working on helping someone debug an issue where Gremlex errors on really long queries. I _believe_ it may be due to server configuration. In the mean time I noticed that we were missing a case in our `Socket.Web.recv!` where it could return a close tuple. This is when the websocket receiver closes the connection. The socket library will catch [1006 error codes](https://tools.ietf.org/html/rfc6455#section-7.4.1) and return them as a close tuple with `:abormal`.

This PR addresses that and will returns an error tuple rather than raising an error.

Thanks!