### PR TITLE
Update unfold; it does not take a parameter

### DIFF
--- a/lib/gremlex/graph.ex
+++ b/lib/gremlex/graph.ex
@@ -536,11 +536,6 @@ defmodule Gremlex.Graph do
     enqueue(graph, "unfold", [])
   end
 
-  @spec unfold(Gremlex.Graph.t(), any()) :: Gremlex.Graph.t()
-  def unfold(graph, traversal) do
-    enqueue(graph, "unfold", [traversal])
-  end
-
   @spec as(Gremlex.Graph.t(), List.t() | String.t()) :: Gremlex.Graph.t()
   def as(graph, name) do
     enqueue(graph, "as", name)

--- a/test/graph_test.exs
+++ b/test/graph_test.exs
@@ -864,14 +864,6 @@ defmodule Gremlex.GraphTests do
     end
   end
 
-  describe "unfold/2" do
-    test "adds a unfold function to the queue" do
-      actual_graph = g() |> unfold("foo")
-      expected_graph = Queue.in({"unfold", ["foo"]}, Queue.new())
-      assert actual_graph == expected_graph
-    end
-  end
-
   describe "as/2" do
     test "adds an as function to the queue" do
       actual_graph = g() |> as("foo")


### PR DESCRIPTION
## About
Removes `unfold/2` and its associated test since it does not take in a parameter, as documented on the [site](http://tinkerpop.apache.org/docs/3.4.3/reference/#unfold-step).