### PR TITLE
Update dockerfile-gremlin to resolve errors

### DIFF
--- a/docker-compose/Dockerfile-gremlin
+++ b/docker-compose/Dockerfile-gremlin
@@ -2,6 +2,10 @@ FROM ubuntu:artful
 
 WORKDIR /srv
 
+RUN sed -i 's|archive.ubuntu|old-releases.ubuntu|g' /etc/apt/sources.list
+
+RUN sed -i '/security.ubuntu.com/d' /etc/apt/sources.list
+
 RUN apt-get update
 
 RUN apt-get install -y unzip wget openjdk-9-jdk


### PR DESCRIPTION
## Summary
Based off of [this issue](https://github.com/CityOfZion/neo-python/issues/1001), this PR updates the `Dockerfile-gremlin` file so that running `docker-compose -f docker-compose/docker-compose.yml build` no longer fails.

![image](https://user-images.githubusercontent.com/1560034/66889036-c4a7af00-ef95-11e9-8e88-aa2126682a2d.png)
